### PR TITLE
Switch postgresql tests to jammy

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -141,7 +141,7 @@ async def test_deploy_and_relate_postgresql(ops_test: OpsTest):
             channel="edge",
             application_name=POSTGRESQL[ops_test.cloud_name],
             num_units=1,
-            series="focal",
+            series="jammy",
             trust=True,
         )
     )


### PR DESCRIPTION
The focal version is deprecated and no longer supported: https://github.com/canonical/postgresql-operator/pull/67