### PR TITLE
mongodb runs on jammy now

### DIFF
--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -39,7 +39,7 @@ async def test_deploy(ops_test: OpsTest, app_charm: PosixPath, data_integrator_c
 
 async def test_deploy_and_relate_mongodb(ops_test: OpsTest):
     """Test the relation with MongoDB and database accessibility."""
-    channel = "dpe/edge" if ops_test.cloud_name == "localhost" else "edge"
+    channel = "5/edge" if ops_test.cloud_name == "localhost" else "edge"
     await asyncio.gather(
         ops_test.model.deploy(
             MONGODB[ops_test.cloud_name],

--- a/tests/integration/test_mongodb.py
+++ b/tests/integration/test_mongodb.py
@@ -46,7 +46,7 @@ async def test_deploy_and_relate_mongodb(ops_test: OpsTest):
             channel=channel,
             application_name=MONGODB[ops_test.cloud_name],
             num_units=1,
-            series="focal",
+            series="jammy",
         )
     )
     await ops_test.model.wait_for_idle(apps=[MONGODB[ops_test.cloud_name]], wait_for_active=True)


### PR DESCRIPTION
## Problem
Both MongoDB VM and K8s tests fail to install. 

## Context
A quick glance shows the tests build on `focal` - but the current release of MongoDB on both VM and K8s is `jammy`.

We would like to release the current versions of the MongoDB charms on both `focal` & `jammy`. But with our current CI this is not possible due to limitations with the `upload-charm` action.

## Solution
Set the release to `jammy`

