### PR TITLE
add suborindate charm integration for mongos router

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -31,7 +31,7 @@ requires:
     interface: opensearch_client
     limit: 1
 
-# suborindate charm integrations
+# subordinate charm integrations
 provides:
   mongos:
     interface: mongos_client

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,3 +30,9 @@ requires:
   opensearch:
     interface: opensearch_client
     limit: 1
+
+# suborindate charm integrations
+provides:
+  mongos:
+    interface: mongos_client
+    limit: 1

--- a/src/literals.py
+++ b/src/literals.py
@@ -9,7 +9,8 @@ PEER = "data-integrator-peers"
 MYSQL = "mysql"
 POSTGRESQL = "postgresql"
 MONGODB = "mongodb"
+MONGOS = "mongos"
 KAFKA = "kafka"
 OPENSEARCH = "opensearch"
 
-DATABASES = [MYSQL, MONGODB, POSTGRESQL]
+DATABASES = [MYSQL, MONGODB, POSTGRESQL, MONGOS]


### PR DESCRIPTION
## Summary
Support subordinate charm integrations 

## Future work
Add integration tests, cannot be done until `mongos` charm is updated and `mongos` relies on these changes