### PR TITLE
Added status badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Charmed Data Integrator Operator
+[![Charmhub](https://charmhub.io/data-integrator/badge.svg)](https://charmhub.io/data-integrator)
+[![Release](https://github.com/canonical/data-integrator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/data-integrator/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/data-integrator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/data-integrator/actions/workflows/ci.yaml)
 
 ## Overview
 


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for 
* CharmHub
* Release
* Tests