### PR TITLE
[DPE-4035] Fixing failing opensearch_pipeline

### DIFF
--- a/tests/integration/constants.py
+++ b/tests/integration/constants.py
@@ -4,7 +4,7 @@
 
 DATA_INTEGRATOR = "data-integrator"
 
-TLS_CERTIFICATES_APP_NAME = "tls-certificates-operator"
+TLS_CERTIFICATES_APP_NAME = "self-signed-certificates"
 
 MYSQL = {"localhost": "mysql", "microk8s": "mysql-k8s"}
 POSTGRESQL = {"localhost": "postgresql", "microk8s": "postgresql-k8s"}


### PR DESCRIPTION
Note: Opensearch still doesn't seem stable -- took a 2nd attempt to get the pipeline green.

I'm wondering how to ensure consistently passing tests.
(Generally -- for pipelines that rely on other charms of ours)

Perhaps using an Opensearch revision, that was a "very good", known to be stable release...?