### PR TITLE
[DPE-4811] Disable Postgresql tests for 3.1

### DIFF
--- a/tests/integration/test_postgresql.py
+++ b/tests/integration/test_postgresql.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_deploy(ops_test: OpsTest, app_charm: PosixPath, data_integrator_charm: PosixPath):
+    if (await ops_test.model.get_status()).model.version.startswith("3.1."):
+        pytest.skip("Test is incompatible with Juju 3.1")
+
     await asyncio.gather(
         ops_test.model.deploy(
             data_integrator_charm, application_name="data-integrator", num_units=1, series="jammy"
@@ -46,6 +49,9 @@ async def test_deploy(ops_test: OpsTest, app_charm: PosixPath, data_integrator_c
 @pytest.mark.group(1)
 async def test_deploy_and_relate_postgresql(ops_test: OpsTest, cloud_name: str):
     """Test the relation with PostgreSQL and database accessibility."""
+    if (await ops_test.model.get_status()).model.version.startswith("3.1."):
+        pytest.skip("Test is incompatible with Juju 3.1")
+
     await asyncio.gather(
         ops_test.model.deploy(
             POSTGRESQL[cloud_name],
@@ -143,6 +149,9 @@ async def test_deploy_and_relate_postgresql(ops_test: OpsTest, cloud_name: str):
 @pytest.mark.group(1)
 async def test_deploy_and_relate_pgbouncer(ops_test: OpsTest, cloud_name: str):
     """Test the relation with PgBouncer and database accessibility."""
+    if (await ops_test.model.get_status()).model.version.startswith("3.1."):
+        pytest.skip("Test is incompatible with Juju 3.1")
+
     logger.info(f"Test the relation with {PGBOUNCER[cloud_name]}.")
     num_units = 0 if cloud_name == "localhost" else 1
     await asyncio.gather(


### PR DESCRIPTION
Postgresql should start enforcing juju 3 version > 3.1

Related to:
* https://github.com/canonical/postgresql-k8s-operator/pull/544
* https://github.com/canonical/postgresql-operator/pull/518