### PR TITLE
Downgrade mem profile to "testing"

### DIFF
--- a/tests/integration/test_opensearch.py
+++ b/tests/integration/test_opensearch.py
@@ -104,6 +104,7 @@ async def test_deploy(
             channel="2/edge",
             application_name=OPENSEARCH[cloud_name],
             num_units=2,
+            config={"profile": "testing"},
         ),
         ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=tls_config),
         ops_test.model.deploy(


### PR DESCRIPTION
Currently, OpenSearch deploys using "profile=production" setting, which consumes 50% of the entire host's RAM. This PR decreases the profile to "testing" instead.