### PR TITLE
[DPE-7065] Don't set secret if not leader

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -108,8 +108,6 @@ class IntegratorCharm(CharmBase):
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handle relation broken event."""
-        if not self.unit.is_leader():
-            return
         # update peer databag to trigger the charm status update
         self._update_relation_status(event, Statuses.BROKEN.name)
 
@@ -268,8 +266,6 @@ class IntegratorCharm(CharmBase):
         """Event triggered when a database was created for this application."""
         logger.debug(f"Database credentials are received: {event.username}")
         self._on_config_changed(event)
-        if not self.unit.is_leader():
-            return
         # update values in the databag
         self._update_relation_status(event, Statuses.ACTIVE.name)
 
@@ -277,8 +273,6 @@ class IntegratorCharm(CharmBase):
         """Event triggered when a topic was created for this application."""
         logger.debug(f"Kafka credentials are received: {event.username}")
         self._on_config_changed(event)
-        if not self.unit.is_leader():
-            return
         # update status of the relations in the peer-databag
         self._update_relation_status(event, Statuses.ACTIVE.name)
 
@@ -286,8 +280,6 @@ class IntegratorCharm(CharmBase):
         """Event triggered when an index is created for this application."""
         logger.debug(f"OpenSearch credentials are received: {event.username}")
         self._on_config_changed(event)
-        if not self.unit.is_leader():
-            return
         # update status of the relations in the peer-databag
         self._update_relation_status(event, Statuses.ACTIVE.name)
 
@@ -295,13 +287,13 @@ class IntegratorCharm(CharmBase):
         """Event triggered when the etcd relation is ready."""
         logger.debug("etcd ready received")
         self._on_config_changed(event)
-        if not self.unit.is_leader():
-            return
         # update status of the relations in the peer-databag
         self._update_relation_status(event, Statuses.ACTIVE.name)
 
     def _update_relation_status(self, event: RelationEvent, status: str) -> None:
         """Update the relation status in the peer-relation databag."""
+        if not self.unit.is_leader():
+            return
         self.set_secret("app", event.relation.name, status)
 
     def _on_peer_relation_changed(self, _: RelationEvent) -> None:

--- a/tests/integration/test_kyuubi.py
+++ b/tests/integration/test_kyuubi.py
@@ -171,17 +171,6 @@ async def test_deploy_kyuubi_setup(
         "Waiting for kyuubi, s3-integrator and integration_hub charms to be idle and active..."
     )
 
-    # Wait for everything to settle down
-    await ops_test.model.wait_for_idle(
-        apps=[
-            KYUUBI_APP_NAME,
-            INTEGRATION_HUB_APP_NAME,
-            S3_APP_NAME,
-        ],
-        idle_period=20,
-        status="active",
-    )
-
     # Deploy the postgresql charm and wait
     hub_deploy_args = {
         "application_name": POSTGRESQL_APP_NAME,
@@ -191,11 +180,6 @@ async def test_deploy_kyuubi_setup(
     }
     logger.info("Deploying postgresql charm...")
     await ops_test.model.deploy(POSTGRESQL_APP_NAME, **hub_deploy_args)
-    logger.info("Waiting for postgresql charm to be idle and active...")
-    await ops_test.model.wait_for_idle(
-        apps=[POSTGRESQL_APP_NAME],
-        status="active",
-    )
 
     # Integrate Kyuubi with Postgresql and wait
     logger.info("Integrating kyuubi charm with postgresql charm...")


### PR DESCRIPTION
Relates to https://github.com/canonical/data-integrator/issues/145

* Add/move checks for leadership inside `_update_relation_status()` to avoid errors on leadership change
* Fix Kyuubi test