### PR TITLE
[MISC] Fix PostgreSQL integration tests

### DIFF
--- a/tests/integration/test_postgresql.py
+++ b/tests/integration/test_postgresql.py
@@ -107,7 +107,9 @@ async def test_deploy_and_relate_postgresql(ops_test: OpsTest, cloud_name: str):
     integrator_relation = await ops_test.model.add_relation(
         DATA_INTEGRATOR, POSTGRESQL[cloud_name]
     )
-    await ops_test.model.wait_for_idle(apps=[DATA_INTEGRATOR, POSTGRESQL[cloud_name]])
+    await ops_test.model.wait_for_idle(
+        apps=[DATA_INTEGRATOR, POSTGRESQL[cloud_name]], status="active"
+    )
 
     # check if secrets are used on Juju3
     assert await check_secrets_usage_matching_juju_version(
@@ -155,12 +157,14 @@ async def test_deploy_and_relate_pgbouncer(ops_test: OpsTest, cloud_name: str):
             trust=True,
         ),
     )
+
     await ops_test.model.add_relation(PGBOUNCER[cloud_name], POSTGRESQL[cloud_name])
+    await ops_test.model.wait_for_idle(apps=[POSTGRESQL[cloud_name]], status="active")
+
     await ops_test.model.add_relation(PGBOUNCER[cloud_name], DATA_INTEGRATOR)
     await ops_test.model.wait_for_idle(
-        apps=[DATA_INTEGRATOR, PGBOUNCER[cloud_name]], status="active"
+        apps=[PGBOUNCER[cloud_name], DATA_INTEGRATOR], status="active"
     )
-    assert ops_test.model.applications[DATA_INTEGRATOR].status == "active"
 
     logger.info(f"Get credential for {PGBOUNCER[cloud_name]}")
     credentials = await fetch_action_get_credentials(
@@ -207,7 +211,9 @@ async def test_deploy_and_relate_pgbouncer(ops_test: OpsTest, cloud_name: str):
 
     await ops_test.model.wait_for_idle(apps=idle_apps)
     await ops_test.model.add_relation(DATA_INTEGRATOR, PGBOUNCER[cloud_name])
-    await ops_test.model.wait_for_idle(apps=[DATA_INTEGRATOR, PGBOUNCER[cloud_name]])
+    await ops_test.model.wait_for_idle(
+        apps=[DATA_INTEGRATOR, PGBOUNCER[cloud_name]], status="active"
+    )
 
     logger.info("Relate and check the accessibility of the previously created database")
     new_credentials = await fetch_action_get_credentials(

--- a/tests/integration/test_postgresql.py
+++ b/tests/integration/test_postgresql.py
@@ -90,7 +90,7 @@ async def test_deploy_and_relate_postgresql(ops_test: OpsTest, cloud_name: str):
         DATABASE_NAME,
     )
     assert result["ok"]
-    logger.info(f"Check assessibility of inserted data on {POSTGRESQL[cloud_name]}")
+    logger.info(f"Check accessibility of inserted data on {POSTGRESQL[cloud_name]}")
     result = await fetch_action_database(
         ops_test.model.applications[APP].units[0],
         "check-inserted-data",
@@ -121,7 +121,7 @@ async def test_deploy_and_relate_postgresql(ops_test: OpsTest, cloud_name: str):
     )
     assert credentials != new_credentials
     logger.info(
-        f"Check assessibility of inserted data on {POSTGRESQL[cloud_name]} with new credentials"
+        f"Check accessibility of inserted data on {POSTGRESQL[cloud_name]} with new credentials"
     )
     result = await fetch_action_database(
         ops_test.model.applications[APP].units[0],
@@ -132,11 +132,11 @@ async def test_deploy_and_relate_postgresql(ops_test: OpsTest, cloud_name: str):
     )
     assert result["ok"]
 
-    logger.info(f"Unlock (unreleate) {DATA_INTEGRATOR} for the PgBouncer tests")
+    logger.info(f"Unlock (unrelate) {DATA_INTEGRATOR} for the PgBouncer tests")
     await ops_test.model.applications[DATA_INTEGRATOR].remove_relation(
         f"{DATA_INTEGRATOR}:postgresql", f"{POSTGRESQL[cloud_name]}:database"
     )
-    # Ensuring full cleanup of relation traces, avodiing faluire on re-creating it soon
+    # Ensuring full cleanup of relation traces, avoiding failure on re-creating it soon
     sleep(3)
 
 
@@ -184,7 +184,7 @@ async def test_deploy_and_relate_pgbouncer(ops_test: OpsTest, cloud_name: str):
         DATABASE_NAME,
     )
     assert result["ok"]
-    logger.info(f"Check assessibility of inserted data on {PGBOUNCER[cloud_name]}")
+    logger.info(f"Check accessibility of inserted data on {PGBOUNCER[cloud_name]}")
     result = await fetch_action_database(
         ops_test.model.applications[APP].units[0],
         "check-inserted-data",
@@ -216,7 +216,7 @@ async def test_deploy_and_relate_pgbouncer(ops_test: OpsTest, cloud_name: str):
 
     assert credentials != new_credentials
     logger.info(
-        f"Check assessibility of inserted data on {PGBOUNCER[cloud_name]} with new credentials"
+        f"Check accessibility of inserted data on {PGBOUNCER[cloud_name]} with new credentials"
     )
     result = await fetch_action_database(
         ops_test.model.applications[APP].units[0],


### PR DESCRIPTION
This PR fixes PostgreSQL integrations tests, which has been failing since May 8th. See:

- [Last run](https://github.com/canonical/data-integrator/actions/runs/14872994213) where PostgreSQL tests passed (May 7th).
- [Earliest run](https://github.com/canonical/data-integrator/actions/runs/14896507069) where PostgreSQL tests failed (May 8th).

---

Reviewers assigned according to the Data Platform [cross-product page](https://canonical-data.readthedocs-hosted.com/products/cross-team/).