### PR TITLE
[DPE-7597] Remove integration hub add-config action in kyuubi test

### DIFF
--- a/tests/integration/test_kyuubi.py
+++ b/tests/integration/test_kyuubi.py
@@ -157,13 +157,6 @@ async def test_deploy_kyuubi_setup(
         status="active",
     )
 
-    # Add configuration key to prevent resource starvation during tests
-    unit = ops_test.model.applications[INTEGRATION_HUB_APP_NAME].units[0]
-    action = await unit.run_action(
-        action_name="add-config", conf="spark.kubernetes.executor.request.cores=0.1"
-    )
-    _ = await action.wait()
-
     # Integrate Kyuubi with Integration Hub and wait
     logger.info("Integrating kyuubi charm with integration-hub charm...")
     await ops_test.model.add_relation(INTEGRATION_HUB_APP_NAME, KYUUBI_APP_NAME)


### PR DESCRIPTION
## Changes

Remove `add-config` action in kyuubi tests.
Please note that we will soon have a new `profile` config option for kyuubi to achieve the same result.