### PR TITLE
[DPE-10186] add `entity-type` and `entity-permissions` to Valkey integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,16 @@ extra-user-roles - `string`; a comma-separated list of values that contains the 
 extra-group-roles - `string`; a comma-separated list of values that contains the required extra roles `admin` in case of a database or opensearch, or `producer`, `consumer` in case of Kafka.
 
 
-| Product    | database-name      | topic-name         | index-name         | prefix-name        | keyspace-name      | entity-type        | entity-permissions | extra-user-roles   | extra-group-roles  |
-|------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
-| MySQL      | :heavy_check_mark: |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| PostgreSQL | :heavy_check_mark: |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| MongoDB    | :heavy_check_mark: |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Kafka      |                    | :heavy_check_mark: |                    |                    |                    | :white_check_mark: | :white_check_mark: | :heavy_check_mark: | :white_check_mark: |
-| OpenSearch |                    |                    | :heavy_check_mark: |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| etcd       |                    |                    |                    | :heavy_check_mark: |                    |                    |                    |                    |                    |
-| Cassandra  |                    |                    |                    |                    | :heavy_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
-| Valkey     |                    |                    |                    | :heavy_check_mark: |                    |                    |                    |                    |                    |
+| Product    | database-name      | topic-name         | index-name         | prefix-name        | keyspace-name      | entity-type         | entity-permissions | extra-user-roles   | extra-group-roles  |
+|------------|--------------------|--------------------|--------------------|--------------------|--------------------|---------------------|--------------------|--------------------|--------------------|
+| MySQL      | :heavy_check_mark: |                    |                    |                    |                    | :white_check_mark:  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| PostgreSQL | :heavy_check_mark: |                    |                    |                    |                    | :white_check_mark:  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| MongoDB    | :heavy_check_mark: |                    |                    |                    |                    | :white_check_mark:  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Kafka      |                    | :heavy_check_mark: |                    |                    |                    | :white_check_mark:  | :white_check_mark: | :heavy_check_mark: | :white_check_mark: |
+| OpenSearch |                    |                    | :heavy_check_mark: |                    |                    | :white_check_mark:  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| etcd       |                    |                    |                    | :heavy_check_mark: |                    |                     |                    |                    |                    |
+| Cassandra  |                    |                    |                    |                    | :heavy_check_mark: | :white_check_mark:  | :white_check_mark: |                    |                    |
+| Valkey     |                    |                    |                    | :heavy_check_mark: |                    | :white_check_mark:  | :white_check_mark: |                    |                    |
 
 :heavy_check_mark: -> mandatory field
 :white_check_mark: -> optional field

--- a/src/charm.py
+++ b/src/charm.py
@@ -189,7 +189,11 @@ class IntegratorCharm(CharmBase):
             charm=self,
             relation_name=VALKEY,
             requests=[
-                RequirerCommonModel(resource=self.prefix or ""),
+                RequirerCommonModel(
+                    resource=self.prefix or "",
+                    entity_type="GROUP",
+                    entity_permissions=self.entity_permissions_loaded,
+                ),
             ],
             response_model=ValkeyResponseModel,
         )
@@ -890,6 +894,29 @@ class IntegratorCharm(CharmBase):
                 privileges=json.loads(self.entity_permissions),
             )
         ]
+
+    @property
+    def entity_permissions_loaded(self) -> list[EntityPermissionModel]:
+        """Return the configured entity type permissions v1, loaded from configured JSON."""
+        if not self.entity_permissions:
+            return []
+
+        try:
+            entity_permissions_config = json.loads(self.entity_permissions)
+        except json.JSONDecodeError:
+            return []
+
+        entity_permissions = []
+        for permission in entity_permissions_config:
+            entity_permissions.append(
+                EntityPermissionModel(
+                    resource_name=permission.get("resource_name"),
+                    resource_type=permission.get("resource_type"),
+                    privileges=permission.get("privileges"),
+                )
+            )
+
+        return entity_permissions
 
     def get_secret(self, scope: str, key: str) -> Optional[str]:
         """Get secret from the secret storage."""


### PR DESCRIPTION
This PR adds the fields `entity-type` and `entity-permissions` to the interface for Valkey. This is required to implement  LDAP support in Valkey, as a group-mapping is supposed to be configured through Data integrator via the `entity-permissions` config (see [DA269](https://docs.google.com/document/d/1guxZipx-h5kYIKDS0hVQR_o35jtOVqRFci7V_TbcVG4/edit?usp=sharing) for details).

An example configuration would look like this:
```
juju config data-integrator prefix-name="<desired_keyspace>:" entity-type="GROUP" entity-permissions="[{\"resource_name\": \"ldap_users_write\", \"resource_type\": \"acl\", \"privileges\": [\"read\", \"write\", \"pubsub\"]}, {\"resource_name\": \"ldap_users_read\", \"resource_type\": \"acl\", \"privileges\": [\"read\"]}]"

juju config valkey ldap-map="<ldap_group_name>:ldap_users_write,<another_ldap_group>:ldap_users_read"
```