### PR TITLE
Add Ubuntu 26.04 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         include:
           - path: .
-            cache: true
+            cache: false  # TODO: revert when PR merged + charmcraft-hub cache built
           - path: tests/integration/app-charm
             cache: false
     name: Build charm | ${{ matrix.path }}

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -9,6 +9,9 @@ platforms:
   ubuntu@24.04:amd64:
   ubuntu@24.04:arm64:
   ubuntu@24.04:s390x:
+  ubuntu@26.04:amd64:
+  ubuntu@26.04:arm64:
+  ubuntu@26.04:s390x:
 # Files implicitly created by charmcraft without a part:
 # - dispatch (https://github.com/canonical/charmcraft/pull/1898)
 # - manifest.yaml


### PR DESCRIPTION
This PR adds support for the Ubuntu 26.04 base, in order to allow usage alongside 26.04 subordinate charms.