### PR TITLE
Enable CI workflow build cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         include:
           - path: .
-            cache: false  # TODO: revert when PR merged + charmcraft-hub cache built
+            cache: true
           - path: tests/integration/app-charm
             cache: false
     name: Build charm | ${{ matrix.path }}


### PR DESCRIPTION
This PR re-enables the CI workflow build cache after PR https://github.com/canonical/data-integrator/pull/308 added support for the Ubuntu 26.04 base.